### PR TITLE
docs(readme): update link nest-commander

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![CI](https://github.com/jmcdo29/nest-commander/workflows/CI/badge.svg) [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/) [![Coffee](https://badgen.net/badge/Buy%20Me/A%20Coffee/purple?icon=kofi)](https://www.buymeacoffee.com/jmcdo29) [![codebeat badge](https://codebeat.co/badges/886435cf-0ace-403b-8f9c-3e4eb99fbd5d)](https://codebeat.co/projects/github-com-jmcdo29-nest-commander-main)
   
   <p align="center">
-    <a href="jmcdo29.github.io/nest-commander/" target="blank"><img src="apps/docs/static/img/nest-commander-final.svg" width="120" alt="Nest Commander Logo" /></a>
+    <a href="https://jmcdo29.github.io/nest-commander" target="blank"><img src="apps/docs/static/img/nest-commander-final.svg" width="120" alt="Nest Commander Logo" /></a>
   </p>
 </div>
 


### PR DESCRIPTION
This PR updates the link as it is broken leads to a page github with 404